### PR TITLE
Fix version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # discourseer
 
 ## Instalace
-Pro spuštění je potřeba mít nainstalovaný Python 3.8 a vyšší.
+Pro spuštění je potřeba mít nainstalovaný Python 3.8, 3.9, nebo 3.10.
 ```bash
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
Knihovna irrcac není v současné době podporována pro Python 3.11.
`irrcac v0.4.1` (poslední verze) by měla být podporována pro Python 3.9 a 3.10.